### PR TITLE
feat(init): Adds in the ability to initialize a pydotfiles-compliant set of dotfiles

### DIFF
--- a/pydotfiles/api/__init__.py
+++ b/pydotfiles/api/__init__.py
@@ -61,6 +61,9 @@ class ArgumentDispatcher:
         help_description = f"""
         Downloads the dotfiles config repo if it hasn't been cloned to local.
 
+        If a remote repo is not provided pydotfiles will use the basic set of pydotfiles
+        found at https://github.com/JasonYao/pydotfiles-basic.
+
         Pydotfiles's configuration is setup in a fallthrough manner:
             - Command-line arguments passed in override all other configs, and will be persisted in $HOME/.pydotfiles/config.json
             - Any non-overridden arguments is then configured from: $HOME/.pydotfiles/config.json (if it exists)

--- a/pydotfiles/models/constants.py
+++ b/pydotfiles/models/constants.py
@@ -10,4 +10,4 @@ PYDOTFILES_CACHE_DIRECTORY = f"{str(Path.home())}/.pydotfiles"
 External defaults
 """
 DEFAULT_PYDOTFILES_CONFIG_LOCAL_DIRECTORY = f"{str(Path.home())}/.dotfiles"
-DEFAULT_CONFIG_REMOTE_REPO = None
+DEFAULT_CONFIG_REMOTE_REPO = "https://github.com/JasonYao/pydotfiles-basic.git"


### PR DESCRIPTION
## Fixlog
- Fixes #17 

## Changelog
- Adds in the ability to initialize a given directory to be pydotfiles-compliant