### PR TITLE
feat(defaults): Adds in the ability to set default settings for a given OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 # General build settings
 sudo: false
-dist: trusty
+dist: xenial
 language: python
-python:
-  - "3.6"
+
+matrix:
+  include:
+    - python: 3.6
+    # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+    # See https://github.com/travis-ci/travis-ci/issues/9815 for more information
+    - python: 3.7
+      sudo: true
 
 env:
   global:

--- a/pydotfiles/defaults/__init__.py
+++ b/pydotfiles/defaults/__init__.py
@@ -1,0 +1,7 @@
+import platform
+from .primitives import MacVersion, VersionRange, Setting
+
+
+def get_current_mac_version():
+    current_version = platform.mac_ver()[0]
+    return MacVersion.from_version(current_version)

--- a/pydotfiles/defaults/primitives.py
+++ b/pydotfiles/defaults/primitives.py
@@ -1,0 +1,95 @@
+from enum import Enum
+from distutils.version import StrictVersion
+from functools import total_ordering
+import logging
+
+from pydotfiles.utils.io import run_command
+
+logger = logging.getLogger(__name__)
+
+
+class Setting:
+
+    def __init__(self, name, valid_version_range, command, enabled=True, description=None, check_command=None, expected_check_state=None, run_as_sudo=False):
+        self.name = name
+        self.enabled = enabled
+        self.description = description
+        self.valid_version_range = valid_version_range
+        self.command = command
+        self.check_command = check_command
+        self.expected_check_state = expected_check_state
+        self.run_as_sudo = run_as_sudo
+
+    def __str__(self):
+        return f"Setting(name={self.name}, enabled={self.enabled}, description={self.description}, valid_version_range={self.valid_version_range}, command={self.command}, check_command={self.check_command}, expected_check_state={self.expected_check_state})"
+
+    def should_run(self, current_version, sudo_password):
+        if not self.enabled:
+            return False
+
+        if not self.valid_version_range.is_in_range(current_version):
+            return False
+
+        if self.check_command is None:
+            return True
+
+        current_status_check_result = run_command(self.check_command, self.run_as_sudo, sudo_password)
+
+        if current_status_check_result != self.expected_check_state:
+            logger.info(f"Setting: Expected value not found, running command now [action={self.name}, expected={self.expected_check_state.encode('unicode_escape')}, found={current_status_check_result.encode('unicode_escape')}")
+
+        return current_status_check_result != self.expected_check_state
+
+    def run(self, sudo_password):
+        run_command(self.command, self.run_as_sudo, sudo_password)
+
+
+class VersionRange:
+
+    def __init__(self, start, end=None):
+        """
+        A None end is taken to be the equivalent of
+        "currently supported"
+        """
+        self.start = start
+        self.end = end
+
+    def __str__(self):
+        return f"VersionRange(start={self.start}, end={self.end})"
+
+    def is_in_range(self, current_version):
+        if self.end is None:
+            return self.start <= current_version
+        return self.start <= current_version <= self.end
+
+
+@total_ordering
+class MacVersion(Enum):
+
+    YOSEMITE = StrictVersion("10.10")
+
+    EL_CAPITAN = StrictVersion("10.11")
+
+    SIERRA = StrictVersion("10.12")
+
+    HIGH_SIERRA = StrictVersion("10.13")
+
+    MOJAVE = StrictVersion("10.14")
+
+    @staticmethod
+    def from_version(version):
+        if isinstance(version, str):
+            version = StrictVersion(version)
+
+        major_version = version.version[0]
+        minor_version = version.version[1]
+
+        truncated_version = StrictVersion(f"{major_version}.{minor_version}")
+        return MacVersion(truncated_version)
+
+    @staticmethod
+    def from_name(name):
+        return MacVersion[name.upper()]
+
+    def __lt__(self, other):
+        return self.value < other.value

--- a/pydotfiles/loading/__init__.py
+++ b/pydotfiles/loading/__init__.py
@@ -1,0 +1,49 @@
+from pydotfiles.models.utils import load_data_from_file
+from pydotfiles.defaults import MacVersion, VersionRange, Setting
+
+
+def get_os_default_settings(default_setting_file_path):
+    # Loads in the default settings file
+    default_settings_data = load_data_from_file(default_setting_file_path)
+
+    # Parses the default settings data
+    return parse_default_settings(default_settings_data)
+
+
+"""
+Parsing methods
+"""
+
+
+def parse_default_settings(default_settings_data):
+    if not default_settings_data:
+        default_settings_data = []
+
+    settings = []
+    for raw_setting in default_settings_data:
+        name = raw_setting.get("name")
+        enabled = raw_setting.get("enabled", True)
+        description = raw_setting.get("description")
+        start = MacVersion.from_name(raw_setting.get("start"))
+
+        raw_end = raw_setting.get("end")
+        end = None if raw_end is None else MacVersion.from_name(raw_end)
+
+        valid_version_range = VersionRange(start, end)
+        command = raw_setting.get("command")
+        check_command = raw_setting.get("check_command")
+        expected_check_state = raw_setting.get("expected_check_state")
+
+        run_as_sudo = raw_setting.get("run_as_sudo", False)
+        settings.append(Setting(
+            name=name,
+            valid_version_range=valid_version_range,
+            command=command,
+            enabled=enabled,
+            description=description,
+            check_command=check_command,
+            expected_check_state=expected_check_state,
+            run_as_sudo=run_as_sudo
+        ))
+
+    return settings

--- a/pydotfiles/resources/schemas/alpha.json
+++ b/pydotfiles/resources/schemas/alpha.json
@@ -42,6 +42,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "default_settings_file": {
+                    "type": "string"
                 }
             },
             "required": ["name"]

--- a/tests/resources/validator/valid_schema_all.json
+++ b/tests/resources/validator/valid_schema_all.json
@@ -53,7 +53,8 @@
             "Notes",
             "iTunes",
             "appstore"
-        ]
+        ],
+        "default_settings_file": "default-settings.json"
     },
     "environments": [
         {

--- a/tests/resources/validator/valid_schema_os.json
+++ b/tests/resources/validator/valid_schema_os.json
@@ -18,6 +18,7 @@
             "Notes",
             "iTunes",
             "appstore"
-        ]
+        ],
+        "default_settings_file": "default-settings.json"
     }
 }

--- a/tests/test_utils/test_io.py
+++ b/tests/test_utils/test_io.py
@@ -2,7 +2,7 @@ import os
 import filecmp
 import pytest
 
-from pydotfiles.utils import mv_file, rm_file, copy_file, symlink_file, unsymlink_file, run_file
+from pydotfiles.utils import mv_file, rm_file, copy_file, symlink_file, unsymlink_file, run_file, run_command
 from pydotfiles.utils import is_moved, is_broken_link, is_linked, is_copied, is_executable
 
 
@@ -214,6 +214,35 @@ def test_run_file_fail_no_execution_bit_set(tmpdir):
     with pytest.raises(RuntimeError):
         # System under test
         run_file(some_script_file)
+
+
+"""
+Run command tests
+"""
+
+
+def test_run_command_success(tmpdir):
+    # Setup
+    some_file = tmpdir.join("test.txt")
+    some_file.write("testing")
+
+    # Setup
+    output = run_command("ls " + tmpdir.realpath().__str__())
+
+    # Verification
+    assert output == "test.txt"
+
+
+def test_run_command_fail_none():
+    with pytest.raises(RuntimeError):
+        # System under test
+        run_command(None)
+
+
+def test_run_command_fail_executable_not_found_in_path():
+    with pytest.raises(RuntimeError):
+        # System under test
+        run_command("commandabc")
 
 
 """


### PR DESCRIPTION
## Fixlog
- Fixes #46 

## Changelog
- Adds in the ability to add in a `default_settings_file` string field to OS objects, pointing to a given file that is then parsed, and which subsequently checks through all the settings in there

## Notes
- Post commands are not added in the initial PR, which is to solve the first problem of "given this configuration, run it". To follow along with those issues, see #48